### PR TITLE
updated help events and output

### DIFF
--- a/index.js
+++ b/index.js
@@ -887,8 +887,8 @@ Command.prototype.usage = function(str) {
     return humanReadableArgName(arg);
   });
 
-  var usage = '[options]'
-    + (this.commands.length ? ' [command]' : '')
+  var usage = (this.commands.length ? '[command]' : '')
+    + ' [options] '
     + (this._args.length ? ' ' + args.join(' ') : '');
 
   if (0 == arguments.length) return this._usage || usage;
@@ -1002,6 +1002,7 @@ Command.prototype.helpInformation = function() {
   if (this._alias) {
     cmdName = cmdName + '|' + this._alias;
   }
+
   var usage = [
     ''
     ,'  Usage: ' + cmdName + ' ' + this.usage()
@@ -1034,13 +1035,18 @@ Command.prototype.helpInformation = function() {
  */
 
 Command.prototype.outputHelp = function(cb) {
+  this.emit('--helpStart');
+
   if (!cb) {
     cb = function(passthru) {
       return passthru;
     }
   }
+
   process.stdout.write(cb(this.helpInformation()));
+
   this.emit('--help');
+  this.emit('--helpEnd');
 };
 
 /**
@@ -1126,4 +1132,3 @@ function exists(file) {
     return false;
   }
 }
-

--- a/index.js
+++ b/index.js
@@ -959,7 +959,7 @@ Command.prototype.commandHelp = function() {
 
     return [
       cmd._name
-        + (cmd._alias ? '|' + cmd._alias : '')
+        + (cmd._alias ? ' | ' + cmd._alias : '')
         + (cmd.options.length ? ' [options]' : '')
         + ' ' + args
       , cmd._description
@@ -1000,7 +1000,7 @@ Command.prototype.helpInformation = function() {
 
   var cmdName = this._name;
   if (this._alias) {
-    cmdName = cmdName + '|' + this._alias;
+    cmdName = cmdName + ' | ' + this._alias;
   }
 
   var usage = [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/commander",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "the complete solution for node.js command-line programs",
   "keywords": [
     "commander",


### PR DESCRIPTION
@Shopify/themes-fed @cshold 

- adds a `helpStart` and `helpEnd` event
- flips `Usage: [options] [command]` for the more accurate `Usage: [command] [options]`

![screenshot 2016-11-14 15 23 53](https://cloud.githubusercontent.com/assets/1938373/20281404/5f83d0b8-aa7e-11e6-8713-6b2fd810f902.png)
